### PR TITLE
Fix import in protocols package

### DIFF
--- a/protocols/__init__.py
+++ b/protocols/__init__.py
@@ -1,3 +1,6 @@
 from .active_enum import active_enum_tcp, active_enum_udp, validate_inputs, create_packet
 from .banner_grabbing import grab_banner, PORT_COMMANDS
-from .host_discovery_module import discover_hosts
+# O módulo correto de descoberta de hosts é `host_discovery`. O nome
+# `host_discovery_module` não existe e fazia o import falhar ao usar
+# o pacote via `from protocols import discover_hosts`.
+from .host_discovery import discover_hosts


### PR DESCRIPTION
## Summary
- fix import path for host discovery module

## Testing
- `python -m py_compile application/scanner_it.py protocols/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68426e6d61a483308919b93590077dd9